### PR TITLE
Log Git Version and Runtime Information as metadata.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,6 @@ logs/
 
 # Folder that has CTRE Phoenix Sim device config storage
 ctre_sim/
+
+# gversion build constants.
+src/main/java/frc/robot/BuildConstants.java

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "2024.3.2"
+    id "com.peterabeles.gversion" version "1.10"
 }
 
 java {
@@ -121,4 +122,15 @@ configurations.all {
 task(checkAkitInstall, dependsOn: "classes", type: JavaExec) {
     mainClass = "org.littletonrobotics.junction.CheckInstall"
     classpath = sourceSets.main.runtimeClasspath
+}
+
+project.compileJava.dependsOn(createVersionFile)
+
+gversion {
+    srcDir       = "src/main/java/"
+    classPackage = "frc.robot"
+    className    = "BuildConstants"
+    dateFormat   = "yyyy-MM-dd HH:mm:ss z"
+    timeZone     = "PST" // Use preferred time zone
+    indent       = "    "
 }

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -32,8 +32,30 @@ public class Robot extends LoggedRobot {
     */
     @Override
     public void robotInit() {
-        Logger.recordMetadata("Project", "StudentAllegro2024"); // Set a metadata value
         
+        // Record gversion metadata.
+
+        Logger.recordMetadata("Robot", Constants.ROBOT.toString());
+        Logger.recordMetadata("ProjectName", BuildConstants.MAVEN_NAME);
+        Logger.recordMetadata("BuildDate", BuildConstants.BUILD_DATE);
+        Logger.recordMetadata("GitSHA", BuildConstants.GIT_SHA);
+        Logger.recordMetadata("GitDate", BuildConstants.GIT_DATE);
+        Logger.recordMetadata("GitBranch", BuildConstants.GIT_BRANCH);
+        Logger.recordMetadata("RuntimeEnvironment", getRuntimeType().toString());
+
+        switch (BuildConstants.DIRTY) {
+            case 0:
+                Logger.recordMetadata("GitDirty", "All changes committed");
+                break;
+            case 1:
+                Logger.recordMetadata("GitDirty", "Uncomitted changes");
+                break;
+            default:
+                Logger.recordMetadata("GitDirty", "Unknown");
+                break;
+        }
+        
+        // Set up data flow
         switch (Constants.ROBOT_MODE) {
             case REAL:
                 Logger.addDataReceiver(new WPILOGWriter());


### PR DESCRIPTION
Installs GVersion,  and logs git version information and runtime information as metadata.

For competitions check out a branch specifically for that competition, be sure to commit every change. This can be handled automatically with a VSCode extension, [Event Deploy for WPILib](https://marketplace.visualstudio.com/items?itemName=Mechanical-Advantage.event-deploy-wpilib).

This will require that all programmers' laptops will need to have git installed, and in their PATH.

Install git [here](https://git-scm.com/downloads) if you dont have it.
P.S. Github Desktop is not the same as git. 

For more information on the uses of this, please look on AdvantageKit's documentation [here](https://docs.advantagekit.org/installation/version-control).